### PR TITLE
Default log_level changed in sensu container

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ This implementation of collectd comes with a few basic checks, as well as a cust
 
 Demo web app container (to demonstrate use of monitoring proxy).
 
+## Sensu
+
+The defautl log_level is 'warn'.  To change this use the following environment variable:
+-  SENSU_DEFAULT_LOG_LEVEL
+
+
 ## Sensu-Client
 
 #### Base checks

--- a/sensu/Dockerfile
+++ b/sensu/Dockerfile
@@ -15,3 +15,4 @@ ADD  docker/my_init.d /etc/my_init.d
 RUN  chmod a+x /etc/my_init.d/*
 
 ENV OPG_SERVICE sensu
+ENV SENSU_DEFAULT_LOG_LEVEL warn

--- a/sensu/Dockerfile
+++ b/sensu/Dockerfile
@@ -9,6 +9,8 @@ RUN \
   && apt-get upgrade -y \
   && apt-get install -y sensu
 
+ADD docker/confd /etc/confd
+
 ADD  docker/my_init.d /etc/my_init.d
 RUN  chmod a+x /etc/my_init.d/*
 

--- a/sensu/docker/confd/conf.d/sensu.toml
+++ b/sensu/docker/confd/conf.d/sensu.toml
@@ -1,0 +1,7 @@
+[template]
+prefix = "/sensu"
+src = "sensu.tmpl"
+dest = "/etc/default/sensu"
+keys = [
+    "/default"
+]

--- a/sensu/docker/confd/templates/sensu.tmpl
+++ b/sensu/docker/confd/templates/sensu.tmpl
@@ -1,0 +1,7 @@
+EMBEDDED_RUBY=false
+{{ if exists "/sensu/default/log/level" }}
+LOG_LEVEL={{ getv "/sensu/default/log/level" }}
+{{ else }}
+LOG_LEVEL=warn
+{{ end }}
+

--- a/sensu/docker/confd/templates/sensu.tmpl
+++ b/sensu/docker/confd/templates/sensu.tmpl
@@ -1,7 +1,2 @@
 EMBEDDED_RUBY=false
-{{ if exists "/sensu/default/log/level" }}
 LOG_LEVEL={{ getv "/sensu/default/log/level" }}
-{{ else }}
-LOG_LEVEL=warn
-{{ end }}
-


### PR DESCRIPTION
All other sensu images inherit and thus can use it.  Override with the SENSU_DEFAULT_LOG_LEVEL env var
