### PR TITLE
Whisper datapoint retention reduced

### DIFF
--- a/graphite-statsd/docker/graphite/conf/storage-schemas.conf
+++ b/graphite-statsd/docker/graphite/conf/storage-schemas.conf
@@ -8,7 +8,10 @@
 # Carbon's internal metrics. This entry should match what is specified in
 # CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
 
+[docker_network_interfaces]
+pattern = interface\.veth
+retentions = 10s:1d,5m:7d
 
 [default]
 pattern = .*
-retentions = 10s:10d,5m:400d,24h:20y
+retentions = 10s:1d,5m:7d,1h:1d,1d:1y


### PR DESCRIPTION
Change default retention for Whisper to more sensible values.  Reduction from 208,900 data points down to about 15,000.
