### PR TITLE
Opgops 1058 monitoring filling up

### DIFF
--- a/graphite-statsd/docker/graphite/conf/storage-schemas.conf
+++ b/graphite-statsd/docker/graphite/conf/storage-schemas.conf
@@ -14,4 +14,4 @@ retentions = 10s:1d,5m:7d
 
 [default]
 pattern = .*
-retentions = 10s:1d,5m:7d,1h:1d,1d:1y
+retentions = 10s:1d,5m:7d,1h:30d,1d:1y

--- a/graphite-statsd/docker/graphite/conf/storage-schemas.conf
+++ b/graphite-statsd/docker/graphite/conf/storage-schemas.conf
@@ -8,7 +8,10 @@
 # Carbon's internal metrics. This entry should match what is specified in
 # CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
 
+[docker_network_interfaces]
+pattern = interface\.veth
+retentions = 10s:1d,5m:7d
 
 [default]
 pattern = .*
-retentions = 10s:10d,5m:400d,24h:20y
+retentions = 10s:1d,5m:7d,1h:1d,1d:1y


### PR DESCRIPTION
Default retention settings reduce number of data points from 208900 down to around 15000
