### PR TITLE
Brute force fix for docker version extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ newtag := $(shell semvertag bump patch)
 
 registryUrl ?= registry.service.opg.digital
 oldRegistryUrl ?= registry.service.dsd.io
-dockerVersion := $(shell docker --version | cut -f3 -d' '  | grep '^1\.[0-9]\.')
+dockerVersion := $(shell docker --version | cut -f3 -d' '  | cut -f1 -d',')
 
 .PHONY: build push pull $(containers) clean showinfo
 


### PR DESCRIPTION
```
> make -n 
make -C grafana newtag=xxxx dockerVersion=
> docker --version 
Docker version 1.12.3, build 6b644ec
> docker --version | cut -f3 -d' '
1.12.3,
> docker --version | cut -f3 -d' ' | grep '^1\.[0-9]\.'
> docker --version | cut -f3 -d' ' | cut -f1 -d','
1.12.3
> make -n 
make -C grafana newtag=xxxx dockerVersion=1.12.3
```
